### PR TITLE
Adjust compiler setting if building the plugin on Linux using gcc 5.0…

### DIFF
--- a/export_dagmc_cmd/CMakeLists.txt
+++ b/export_dagmc_cmd/CMakeLists.txt
@@ -5,6 +5,15 @@ cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+# adjust compiler setting for Linux using gcc version 5.0 and higher
+if(CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0")
+    if(NOT CMAKE_CXX_FLAGS MATCHES _GLIBCXX_USE_CXX11_ABI)
+      set(CMAKE_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0 ${CMAKE_CXX_FLAGS}")
+    endif()
+  endif()
+endif()
+
 # Get the packages needed to use the SDK
 find_package(Cubit REQUIRED CONFIG)
 include_directories(${CUBIT_INCLUDE_DIRS})


### PR DESCRIPTION
Added the suggested compiler setting fix to the cmake build. I tested this using gcc 5.4.0 and it worked well.
