### PR TITLE
Adding file set for preserved tagging of facet and geometry resolution tolerances.

### DIFF
--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -178,7 +178,7 @@ moab::ErrorCode DAGMCExportCommand::parse_options(CubitCommandData &data, moab::
   if (verbose_warnings && fatal_on_curves)
     message << "This export will fail if curves fail to facet" << std::endl;
 
-
+  return rval;
 }
 
 moab::ErrorCode DAGMCExportCommand::create_tags()

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -32,7 +32,7 @@ public:
 protected:
 
   moab::ErrorCode create_tags();
-  moab::ErrorCode parse_options(CubitCommandData &data, moab::EntityHandle* file_set);
+  moab::ErrorCode parse_options(CubitCommandData &data, moab::EntityHandle* file_set = 0);
   moab::ErrorCode create_entity_sets(refentity_handle_map (&entmap)[5]);
   moab::ErrorCode create_topology(refentity_handle_map (&entitymap)[5]);
   moab::ErrorCode store_surface_senses(refentity_handle_map& surface_map,

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -32,7 +32,7 @@ public:
 protected:
 
   moab::ErrorCode create_tags();
-  moab::ErrorCode parse_options(CubitCommandData &data);
+  moab::ErrorCode parse_options(CubitCommandData &data, moab::EntityHandle* file_set);
   moab::ErrorCode create_entity_sets(refentity_handle_map (&entmap)[5]);
   moab::ErrorCode create_topology(refentity_handle_map (&entitymap)[5]);
   moab::ErrorCode store_surface_senses(refentity_handle_map& surface_map,
@@ -47,6 +47,7 @@ protected:
                                       refentity_handle_map& vertex_map);
   moab::ErrorCode create_surface_facets(refentity_handle_map& surface_map,
                                         refentity_handle_map& vertex_map);
+  moab::ErrorCode gather_ents(moab::EntityHandle gather_set);  
   void teardown();
 
 private:


### PR DESCRIPTION
In order for tagged information to be preserved through file writing/loading, all of the entities created need to be gathered into a single MeshSet and written to file. Upon loading the file, this MeshSet will be recognized as the file set so that any information tagged on it can be retrieved.

This information is sought out by make_watertight. 

These changes have been tested with the plugin (complied using gcc/g++ version < 5.0)  and files can now be made watertight.
